### PR TITLE
Add project license to metainfo

### DIFF
--- a/data/eksanos.metainfo.xml
+++ b/data/eksanos.metainfo.xml
@@ -6,6 +6,7 @@
 	<name>Eksanos</name>
 	<summary>A simple TicTacToe app</summary>
 	<description><p>Play the classic game of Naughts and Crosses by yourself or with a friend!</p></description>
+	<project_license>GPL-3.0-or-later</project_license>
 
 	<launchable type="desktop-id">com.github.eksanos.eksanos.desktop</launchable>
 


### PR DESCRIPTION
I added the project license to the app's metadata, either way, other software stores like GNOME Software will display the app as proprietary and *potentially insecure*.
![Eksanos screenshot in GNOME Software, the app is described as potentially insecure and proprietary](https://user-images.githubusercontent.com/76420970/166977100-b8e4bd23-ca72-430a-b890-e234a115941d.png)